### PR TITLE
Fix HuggingFaceDataLoader mask casting for point cloud datasets

### DIFF
--- a/agml/data/hf_loader.py
+++ b/agml/data/hf_loader.py
@@ -3,7 +3,7 @@ import math
 from typing import List, Union
 
 try:
-    from datasets import load_dataset, DatasetDict, Image, Sequence, ClassLabel
+    from datasets import load_dataset, DatasetDict, Image, Sequence, ClassLabel, Array2D
 except ImportError:
     raise ImportError(
         "The `datasets` library is required to use the HuggingFaceDataLoader. "
@@ -80,8 +80,10 @@ class HuggingFaceDataLoader(AgMLSerializable):
         if "image" in features and not isinstance(features["image"], Image):
             ds = ds.cast_column("image", Image())
 
-        # A "mask" column is always a pixel map — cast unconditionally.
-        if "mask" in features and not isinstance(features["mask"], Image):
+        # A "mask" column is a pixel map for image datasets, but a per-point
+        # label array (Array2D) for point cloud datasets. Only cast to
+        # Image() when it isn't already a numeric array type.
+        if "mask" in features and not isinstance(features["mask"], (Image, Array2D)):
             ds = ds.cast_column("mask", Image())
 
         return ds


### PR DESCRIPTION
## Fix HuggingFaceDataLoader to support point cloud mask columns

### What
`_cast_single` in `agml/data/hf_loader.py` unconditionally cast any `mask` column to `Image()`, assuming masks are always pixel maps. Point cloud datasets (e.g. `Project-AgML/pheno4d_point_cloud_segmentation`) store `mask` as `Array2D` (per-point label arrays), since there's no image to draw a pixel mask onto for 3D data. The unconditional cast broke loading for these datasets.

### Fix
Only cast `mask` to `Image()` when it isn't already `Image` or `Array2D`. No changes needed for object detection, `objects` isn't handled specially in this file, so point cloud detection datasets already pass through unaffected.

### Tested against the real, live dataset
```python
from agml.data.hf_loader import HuggingFaceDataLoader
loader = HuggingFaceDataLoader("Project-AgML/pheno4d_point_cloud_segmentation", "raw")
row = loader.dataset["train"][0]
print(type(row["mask"]))  # <class 'list'>, not PIL.Image
```
Confirmed `mask` comes back as its correct raw nested-list form (convertible via `np.array()`), not miscast into an image, no data loss or corruption.